### PR TITLE
Add Oracle Linux 7 to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,12 @@
       "operatingsystemrelease": [
         "7"
       ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "7"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Added OEL7 as it works well on here.

We are using it on OEL7 in production. 

Thank you very much for creating a simple, easy to use freeradius module.

Luke
