### PR TITLE
Added example for sql. And CentOS7

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ file { '/etc/raddb/mods-config/perl/auth.pl':
 }
 ```
 
+Please see the Examples directory for further details
+
+

--- a/examples/mod_sql.pp
+++ b/examples/mod_sql.pp
@@ -1,0 +1,12 @@
+# ### Manage a module using a template file
+# ```puppet
+class { 'freeradius': }
+
+
+freeradius::mod { 'sql':
+  ensure  => present,
+  package => 'freeradius-mysql',
+  content => template('module/radius_sql.erb'),
+}
+
+# ```

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,12 @@
       "operatingsystemrelease": [
         "7"
       ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7"
+      ]
     }
   ]
 }


### PR DESCRIPTION
As per commit.

I have added a example of the content => template syntax as using inline templates can become a little challenging with very large config files.

Also added CentOS7, which should work fine.

cheers,
Luke
